### PR TITLE
fix sha256 hash for R-3.1.3-mavericks.pkg

### DIFF
--- a/Casks/r.rb
+++ b/Casks/r.rb
@@ -7,7 +7,7 @@ cask :v1 => 'r' do
     url "http://cran.rstudio.com/bin/macosx/R-#{version}-snowleopard.pkg"
     pkg "R-#{version}-snowleopard.pkg"
   else
-    sha256 'bd150f488c36e3d793febd3b7f619c076fc3bccfe673592af3134c32118d1c5e'
+    sha256 '28445419c73b03dd3e0e1199114e23c83e56a5140f8c43f37b63cb550dc0eba7'
     # rstudio.com is the official download host per the vendor homepage
     url "http://cran.rstudio.com/bin/macosx/R-#{version}-mavericks.pkg"
     pkg "R-#{version}-mavericks.pkg"


### PR DESCRIPTION
Here are SHA1 and SHA256 for the R 3.1.3 package.
Only SHA1 is mentioned in the web page.

:~/Downloads$ shasum -a 256 R-3.1.3-mavericks.pkg
28445419c73b03dd3e0e1199114e23c83e56a5140f8c43f37b63cb550dc0eba7  R-3.1.3-mavericks.pkg
:~/Downloads$ shasum -a 1 R-3.1.3-mavericks.pkg
200349fbcfd14b8b4769b52340164dd728c3995c  R-3.1.3-mavericks.pkg
